### PR TITLE
更改正则表达式; 添加能获取到的元信息

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -197,26 +197,17 @@ def toMetadata(log, gmetadata, ExHentai_Status, Chinese_Status,sqlitUrl):  # {{{
     mi.identifiers = {'ehentai': '%s_%s_%d' % (str(gid), str(token), int(ExHentai_Status))}
     mi.publisher = publisher if publisher else None
 
-    # Tags
+    # tags and languages
     tags_ : Set[str] = set()
+    languages: Set[str] = set()
     for tag in tags:
+        tags_.add(tag)
         if re.match('language', tag):
-            # FIXME: a gallary might have multiple languages
             tag_ = re.sub('language:', '', tag)
             if tag_ != 'translated':
-                mi.language = tag_
-            else:
-                tags_.add(tag)
-                #         elif re.match('parody|group|character|artist', tag):
-                #             log('drop tag %s' % tag)
-                #             continue
-        elif not ':' in tag:
-            log('drop tag %s' % tag)
-            continue
+                languages.add(tag_)
         elif re.match('parody', tag):
             is_parody = True 
-        else:
-            tags_.add(tag)
 
     tags_.add('category:%s' % category)
 
@@ -232,11 +223,13 @@ def toMetadata(log, gmetadata, ExHentai_Status, Chinese_Status,sqlitUrl):  # {{{
             tags_.add('other:%s' % OTHER_DICT[addtion])
         elif addtion in LANGUAGE_DICT:
             tags_.add('language:%s' % LANGUAGE_DICT[addtion])
+            languages.add(LANGUAGE_DICT[addtion])
         else:
             # assume addtion fields that aren't languages nor other tags are translators
             tags_.add('translator:%s' % addtion)
 
     mi.tags = list(tags_)
+    mi.languages = list(languages)
 
     # rating
     mi.rating = float(rating)

--- a/__init__.py
+++ b/__init__.py
@@ -128,7 +128,7 @@ def to_metadata(log, gmetadata, ExHentai_Status, Chinese_Status,sqlitUrl):  # {{
             if tag_ != 'translated':
                 mi.language = tag_
             else:
-                tags_.append(tag_)
+                tags_.append(tag)
                 #         elif re.match('parody|group|character|artist', tag):
                 #             log('drop tag %s' % tag)
                 #             continue

--- a/__init__.py
+++ b/__init__.py
@@ -195,7 +195,7 @@ def toMetadata(log, gmetadata, ExHentai_Status, Chinese_Status,sqlitUrl):  # {{{
 
     mi = Metadata(title_, authors)
     mi.identifiers = {'ehentai': '%s_%s_%d' % (str(gid), str(token), int(ExHentai_Status))}
-    mi.publisher = publisher if publisher else None
+    mi.publisher = publisher if publisher else 'Unknown'
 
     # tags and languages
     tags_ : Set[str] = set()


### PR DESCRIPTION
# 做出的修改

- 修改从标题中获取作者等信息的正则表达式, 参见源码.
- 更改了从 accurate url 获取 metadata 的逻辑, 增加了解析到的元信息的种类, 参见下一节.

# 从 accurate url 获取 metadata 的逻辑

1.  利用 e-hentai API 获取 json 形式的元数据 `gmetadata`
1.  利用正则表达式将 `gmetadata['title']` 解析为 `publisher`, `author`, `title_`, `magazine_or_parody`, `addtions`; 同时也从 `gmetadata` 中得到标签, 上传者等信息.

    - 之所以是 `magazine_or_parody`, 是因为对于改编同人本来说, 标题后面的 `()` 内是原作名, 例如 `(C99) [Koori Ame (Hisame Genta)] Nagiko-san Crisis (Fate/Grand Order) [Chinese] [黑锅汉化组]` 中的 `(Fate/Grand Order)`; 而对于原创同人本, 标题后面的 `()` 内是杂志名, 例如 `[Ash Yokoshima] Kanente-san to Oonawa-kun (COMIC X-EROS #85) [Chinese] [零食汉化组] [Digital]` 中的 `(COMIC X-EROS #85)`. 具体是 `parody` 还是 `magazine` 会在后面进行判断.
    - `addtions` 中可能有三类内容, 均被方括号括起来. 一部分描述语言, 例如 `Chinese` (在英文标题中出现), `中国翻訳` (在日文标题中出现); 一部分描述漫画的特征, 例如 `无修正`, `Full Color`; 还有一部分描述翻译者, 例如 `零食汉化组`.

1.  把前面解析得到的信息转换为 `calibre` 的元数据. 一些特殊处理如下
  
    - 解析标签里有没有 `parody`, 如果有, 那么认为 `magazine_or_parody` 中储存的是原作名; 否则认为储存的是杂志名, 存为 `magazine:<杂志名>`
    - 将 `addtions` 中的语言信息存为 `language:<语言>`; 其中的漫画特征存为 `other:<漫画特征>`; 翻译者存为 `translator:<翻译者>`
    - 将 `category` 存为 `category:<画廊类别>`
    - 以上特殊存储规则都存到 `calibre` 的标签中 (因为 `calibre` 不允许 `Metadata source` 类型的插件设置默认属性以外的内容 <https://www.mobileread.com/forums/showthread.php?t=289536>), 或许之后会写一个插件将相应标签更新到 `custom column` 中.

另注: 以上内容均靠归纳得到, 仅仅是对原来插件规则的完善, 无法覆盖所有漫画.
